### PR TITLE
Fixed error on posting new article

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -137,7 +137,7 @@ class ArticlesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def article_params
-    if @article.user_id == current_user.id
+    if @article and @article.user_id == current_user.id
       params.require(:article).permit(:user_id, :title, :body, :lock_version, :is_public_editable)
     else
       params.require(:article).permit(:user_id, :title, :body, :lock_version)


### PR DESCRIPTION
develop で新規記事投稿ができなかったので、修正してみました。

```
NoMethodError in ArticlesController#create
undefined method `user_id' for nil:NilClass
Extracted source (around line #140):

# Never trust parameters from the scary internet, only allow the white list through.
def article_params
if @article.user_id == current_user.id
params.require(:article).permit(:user_id, :title, :body, :lock_version, :is_public_editable)
else
params.require(:article).permit(:user_id, :title, :body, :lock_version)

Rails.root: /vagrant
Application Trace | Framework Trace | Full Trace

app/controllers/articles_controller.rb:140:in `article_params'
app/controllers/articles_controller.rb:85:in `create'
config/initializers/quiet_assets.rb:6:in `call_with_quiet_assets'
```
