### PR TITLE
Added rvm versions: 2.0.0 and 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
     - 1.9.3
+    - 2.0.0
+    - 2.1.2
 before_script:
     - mysql -e 'create database lodge_test'
     - cp config/database.test.yml config/database.yml


### PR DESCRIPTION
Travis CI の rvm の対象バージョンが 1.9.3 だけになっていたため、 2.0.0, 2.1.2 を追加しました
