### PR TITLE
Fixed an error in the user information

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -13,7 +13,7 @@ module ArticlesHelper
     if user_stock
       link_to %!#{image_tag("stocked.png")}#{article.stocks.size}!.html_safe, user_stock, method: :delete, class: "stock-link", title: tco(:unstock)
     else
-      link_to %!#{image_tag("unstocked.png")}#{article.stocks.size}!.html_safe, {controller: "stocks", article_id: article.id}, method: :post, class: "stock-link", title: tco(:stock)
+      link_to %!#{image_tag("unstocked.png")}#{article.stocks.size}!.html_safe, {controller: "/stocks", article_id: article.id}, method: :post, class: "stock-link", title: tco(:stock)
     end
   end
 


### PR DESCRIPTION
最近の人気記事に他のユーザからストックされた自分の記事がある状態でユーザ情報の編集画面を開くとエラーになるので修正しました。

```
F, [2014-07-10T21:37:12.702301 #98688] FATAL -- : 
ActionView::Template::Error (No route matches {:action=>"index", :article_id=>1, :controller=>"custom_devise/stocks"}):
    92:           <% @popular_articles.each do |article| %>
    93:             <li>
    94:               <%= link_to "#{article.title}", article_path(article) %>
    95:               <%= stock_and_count_link(article) %>
    96:             </li>
    97:           <% end %>
    98:         </ol>
  app/helpers/articles_helper.rb:16:in `stock_and_count_link'
  app/views/layouts/application.html.erb:95:in `block in _app_views_layouts_application_html_erb___1009971121506697674_70141803188280'
  app/views/layouts/application.html.erb:92:in `each'
  app/views/layouts/application.html.erb:92:in `_app_views_layouts_application_html_erb___1009971121506697674_70141803188280'
  config/initializers/quiet_assets.rb:6:in `call_with_quiet_assets'
```
