### PR TITLE
[bugfix] postgresqlでsqlシンタックスエラーが発生する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
     return unless current_user
     popular_stocks = Stock.joins(:article)
       .where("articles.created_at > ?", 2.week.ago)
-      .group("stocks.article_id")
+      .group("stocks.article_id, articles.updated_at")
       .order("count_article_id desc, articles.updated_at desc")
       .limit(RIGHT_LIST_SIZE)
       .count(:article_id)


### PR DESCRIPTION
素晴らしいプロジェクトをありがとうございます！

postgresqlで動作させようとしたところ、sqlのシンタックスエラーが発生してしまいました。

どうやらgroup byに指定がない列でorder byしようとするので、エラーが発生しているようでした。

(mysqlではgroup by指定していないものでもselectできたはずなので、発生しないと思われます。)

修正しましたので、ご確認をお願いします。
##### syntax error sql

```
SELECT  COUNT("stocks"."article_id") AS count_article_id,
stocks.article_id AS stocks_article_id
FROM "stocks" INNER JOIN "articles" ON "articles"."id" =
"stocks"."article_id"
WHERE (articles.created_at > '2014-07-03 18:05:04.323832')
GROUP BY stocks.article_id
ORDER BY count_article_id desc, articles.updated_at desc LIMIT 10
```
