### PR TITLE
Fixed popular stocks query

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,14 +31,14 @@ class ApplicationController < ActionController::Base
     return unless current_user
     popular_stocks = Stock.joins(:article)
       .where("articles.created_at > ?", 2.week.ago)
-      .group("stocks.article_id, articles.updated_at")
-      .order("count_article_id desc, articles.updated_at desc")
+      .group("stocks.article_id", "articles.updated_at")
+      .order("count_article_id desc", "articles.updated_at desc")
       .limit(RIGHT_LIST_SIZE)
       .count(:article_id)
     popular_articles = Article.includes(:stocks).where(id: popular_stocks.keys)
     @popular_articles = []
-    popular_stocks.each do |article_id, count|
-      @popular_articles << popular_articles.select {|a| a.id == article_id}.first
+    popular_stocks.each do |keys, count|
+      @popular_articles << popular_articles.select {|a| a.id == keys[0]}.first
     end
   end
 


### PR DESCRIPTION
@kakusuke 
#68 の修正によって、 `popular_stocks` が意図しない結果になっていたので、

修正してみました。これにより、 `@popular_articles` の中身が `nil` で落ちることはなくなりますが、
以前からも発生していた以下のテストエラーが解消していません。
当方のマシンでは、 全体の `rspec` で2回に1回ぐらい発生し、`rspec spec/features/edit_articles_spec.rb` では発生しません。
Travis 上でも、[発生したりしなかったりする](https://travis-ci.org/lodge/lodge/builds/30329264)ため、Capybara が要素出現を待てていない（turbolinksのせい？）のかもしれません。

まずは、 stablize_travis ブランチにプルリクエストをします。

```
Failures:

  1) EditArticles edit article and notify editiong to stocked user
     Failure/Error: click_link I18n.t("articles.update_histories")
     Capybara::ElementNotFound:
       Unable to find link "編集履歴"
     # ./spec/features/edit_articles_spec.rb:28:in `block (2 levels) in <top (required)>'

Finished in 16.71 seconds (files took 3.04 seconds to load)
55 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/features/edit_articles_spec.rb:16 # EditArticles edit article and notify editiong to stocked user
```
