### PR TITLE
「編集履歴」がときたまコケる現象に対処

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -14,7 +14,7 @@
   <div id="article-info-area">
     <div id="article-timestamp-area">
       <span><%= tco :created_at %>: <%= @article.created_at %></span>
-      <% if @article.created_at != @article.updated_at %>
+      <% if @article.update_histories.size > 0 %>
         <span>|</span>
         <span><%= tco :updated_at %>: <%= @article.updated_at %></span>
         <span>-</span>


### PR DESCRIPTION
テストで、MySQLのテストのときのみ高頻度でコケるテストがあった
問題は、表示するかどうかの判定を`created_at`と`updated_at`で行っていたため
