### PR TITLE
Bundle warnings の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,16 +86,6 @@ group :test do
   gem 'capybara'
   gem 'poltergeist'
   gem 'database_cleaner'
-  case ENV['DB']
-  when 'sqlite'
-    gem 'sqlite3'
-  when 'mysql'
-    gem 'mysql2'
-  when 'postgresql'
-    gem 'pg'
-  else
-    gem 'sqlite3'
-  end
 end
 
 # Include database gems for the adapters found in the database


### PR DESCRIPTION
Gemfile のアダプタ検出ロジックには config/database.yml 内で使われているアダプタを
すべてインストールするよう書かれているので、テスト時に考慮する必要はない
