### PR TITLE
タグ周りのリファクタリング

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -15,12 +15,10 @@ class ArticlesController < ApplicationController
   # GET /articles
   # GET /articles.json
   def feed
-    following_tags = FollowingTag.includes(:tag).where(user_id: current_user.id)
-    following_tag_names = following_tags.map {|f| f.tag.name } unless following_tags.nil?
     @articles = Article
       .includes(:user, :stocks, :tags)
       .page(params[:page]).per(PER_SIZE)
-      .tagged_with(following_tag_names, any: true)
+      .tagged_with(current_user.following_tag_list, any: true)
       .order(:updated_at => :desc)
     render :index
   end
@@ -51,8 +49,8 @@ class ArticlesController < ApplicationController
   # GET /articles/tag/1
   # GET /articles/tag/1.json
   def by_tag
-    @articles = Article.includes(:tags, :stocks, :user).page(params[:page]).per(PER_SIZE).tagged_with(params[:tag_name]).order(:updated_at => :desc)
-    @tag = Tag.find_by_name(params[:tag_name])
+    @articles = Article.includes(:stocks, :user).page(params[:page]).per(PER_SIZE).tagged_with(params[:tag]).order(:updated_at => :desc)
+    @tag = params[:tag]
     render :index
   end
 

--- a/app/controllers/following_tags_controller.rb
+++ b/app/controllers/following_tags_controller.rb
@@ -1,15 +1,13 @@
 class FollowingTagsController < ApplicationController
-  before_action :set_following_tag, only: [:destroy]
   before_action :check_permission, only: [:destroy]
   before_action :following_tag_params, only: [:create, :destroy]
 
   # POST /articles
   # POST /articles.json
   def create
-    @following_tag = FollowingTag.new(following_tag_params)
-    @following_tag.user_id = current_user.id
+    current_user.following_tag_list << following_tag_params[:tag]
     respond_to do |format|
-      if @following_tag.save
+      if current_user.save
         format.html { redirect_to :back, notice: 'Tag was successfully followed.' }
         format.json { render :show, status: :created, location: @following_tag }
       else
@@ -22,7 +20,8 @@ class FollowingTagsController < ApplicationController
   # DELETE /articles/1
   # DELETE /articles/1.json
   def destroy
-    @following_tag.destroy
+    current_user.following_tag_list.remove(following_tag_params[:tag])
+    current_user.save
     respond_to do |format|
       format.html { redirect_to :back, notice: 'Tag was successfully unfollowed.' }
       format.json { head :no_content }
@@ -33,17 +32,12 @@ class FollowingTagsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def following_tag_params
-    params.permit(:tag_id)
+    params.permit(:tag)
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def check_permission
-    return if @following_tag.user_id == current_user.id
+    return if current_user.follow? following_tag_params[:tag]
     redirect_to articles_url
-  end
-
-  def set_following_tag
-    @following_tag = FollowingTag.where(tag_id: params[:tag_id], user_id: current_user.id).first
-    ap @following_tag
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,7 +2,7 @@ class TagsController < ApplicationController
   # GET /tags
   # GET /tags.json
   def index
-    @tags = Kaminari.paginate_array(Article.tag_counts.order(id: :desc)).page(params[:page]).per(PER_SIZE)
+    @tags = Article.tag_counts.page(params[:page]).per(PER_SIZE).order(id: :desc)
     @following_tags = current_user.following_tag_list
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,7 +2,7 @@ class TagsController < ApplicationController
   # GET /tags
   # GET /tags.json
   def index
-    @tags = Tag.page(params[:page]).per(PER_SIZE).where("taggings_count > ?", 0).order(id: :desc)
-    @following_tags = FollowingTag.includes(:tag).where(user_id: current_user.id)
+    @tags = Kaminari.paginate_array(Article.tag_counts.order(id: :desc)).page(params[:page]).per(PER_SIZE)
+    @following_tags = current_user.following_tag_list
   end
 end

--- a/app/models/following_tag.rb
+++ b/app/models/following_tag.rb
@@ -1,4 +1,0 @@
-class FollowingTag < ActiveRecord::Base
-  belongs_to :user
-  belongs_to :tag
-end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,0 @@
-class Tag < ActiveRecord::Base
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@ class User < ActiveRecord::Base
   validates_presence_of :name
   before_save :generate_gravatar
 
-  has_many :following_tags
   has_many :articles
   has_many :stocked_articles,
     -> {order "stocks.updated_at desc"},
@@ -22,13 +21,14 @@ class User < ActiveRecord::Base
     :through => :notification_targets,
     :source => :notification
 
+  acts_as_taggable_on :following_tags
+
   def generate_gravatar
     self.gravatar = Digest::MD5.hexdigest(self.email)
   end
 
   def follow?(tag)
-    tag_ids = self.following_tags.map { |ft| ft.tag_id }
-    tag_ids.include? tag.id
+    following_tag_list.include? tag
   end
 
   def contribution

--- a/app/views/articles/_article_list.html.erb
+++ b/app/views/articles/_article_list.html.erb
@@ -12,8 +12,9 @@
         </td>
         <td class="article-tags-column">
           <% article.tags.each do |tag| %>
-            <% tag_name = %!<span class="label label-default">#{tag.name}</span>!.html_safe %>
-            <%= link_to tag_name, articles_by_tag_path(tag.name), class: :tag %>
+            <%= link_to articles_by_tag_path(tag.name), class: :tag do %>
+              <span class="label label-default"><%= tag.name %></span>
+            <% end %>
           <% end %>
         </td>
         <td><%= stock_and_comment_count(article) %></td>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -6,7 +6,7 @@
   when "index" %>
     <%= tco("recent_article_list_title") %>
   <% when "by_tag" %>
-    <%= tc("list_title_by_tag", :tag_name => params[:tag_name]) %>
+    <%= tc("list_title_by_tag", :tag => params[:tag]) %>
   <% when "by_stocks" %>
     <%= tco "stocked_article_list_title" %>
   <% when "search" %>
@@ -21,9 +21,9 @@
 
 <% if action == "by_tag" %>
   <% if current_user.follow?(@tag) %> 
-    <%= link_to tc(:unfollow_this_tag), following_tag_path(tag_id: @tag.id), method: :delete %>
+    <%= link_to tc(:unfollow_this_tag), following_tag_path(tag: @tag), method: :delete %>
   <% else %>
-    <%= link_to tc(:follow_this_tag), following_tags_path(tag_id: @tag.id), method: :post %>
+    <%= link_to tc(:follow_this_tag), following_tags_path(tag: @tag), method: :post %>
   <% end %>
 <% end %>
 

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -13,10 +13,10 @@
         <td><%= link_to tag.name, articles_by_tag_path(tag.name), title: tag.name %></td>
         <td class="counts-column text-right"><%= tag.taggings_count %></td>
         <td class="follow-column text-right">
-          <% if @following_tags.map{|ft|ft.tag}.include?(tag) %>
-            <%= link_to tc(:unfollow), following_tag_path(tag_id: tag.id), method: :delete %>
+          <% if @following_tags.include?(tag.name) %>
+            <%= link_to tc(:unfollow), following_tag_path(tag: tag.name), method: :delete %>
           <% else %>
-            <%= link_to tc(:follow), following_tags_path(tag_id: tag.id), method: :post %>
+            <%= link_to tc(:follow), following_tags_path(tag: tag.name), method: :post %>
           <% end %>
         </td>
       </tr>

--- a/config/locales/02_view/en.yml
+++ b/config/locales/02_view/en.yml
@@ -93,7 +93,7 @@ en:
     new_password_title: Forgot your password?
     submit_buttoin: Send me reset password instructions
   articles:
-    list_title_by_tag: "Listing articles of '%{tag_name}'"
+    list_title_by_tag: "Listing articles of '%{tag}'"
     list_title_by_search: "Listing articles of '%{query}' query"
     update_histories: Update histories
     new_title: New article

--- a/config/locales/02_view/ja.yml
+++ b/config/locales/02_view/ja.yml
@@ -93,7 +93,7 @@ ja:
     new_password_title: パスワードの再設定
     submit_button: メール送信
   articles:
-    list_title_by_tag: "'%{tag_name}'のタグが付けられた記事一覧"
+    list_title_by_tag: "'%{tag}'のタグが付けられた記事一覧"
     list_title_by_search: "'%{query}'の検索結果"
     update_histories: 編集履歴
     new_title: 新規作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   resources :users, only: [:show]
 
   match "tags", to: 'tags#index', via: :get
-  match "following_tag", to: 'following_tags#destroy', via: :delete, require: :tag_id
+  match "following_tag", to: 'following_tags#destroy', via: :delete, require: :tag
   resources :following_tags, :only => [:create]
   resources :stocks, :only => [:index, :create, :destroy]
 
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   match "articles/feed", :to => 'articles#feed', :via => :get, :as => :articles_feed
   resources :articles
   match "articles/:id/comment", :to => 'articles#create_comment', :via => :post
-  match "articles/tag/:tag_name", :to => 'articles#by_tag', :via => :get, :as => :articles_by_tag, :constraints => {tag_name: /.+/}
+  match "articles/tag/:tag", :to => 'articles#by_tag', :via => :get, :as => :articles_by_tag, :constraints => {tag: /.+/}
   match "articles/user/:user_id", :to => 'articles#by_user', :via => :get, :as => :articles_by_user
   resources :comments, :only => [:create, :update, :destroy]
 

--- a/db/migrate/20140723002446_migrate_following_tags_to_tagging.rb
+++ b/db/migrate/20140723002446_migrate_following_tags_to_tagging.rb
@@ -1,0 +1,16 @@
+class MigrateFollowingTagsToTagging < ActiveRecord::Migration
+  def up
+    sql = 'SELECT tag_id, user_id, created_at FROM following_tags'
+    for tag in execute(sql)
+      execute("INSERT INTO taggings (tag_id, taggable_id, taggable_type, context, created_at) VALUES(#{tag['tag_id']}, #{tag['user_id']}, 'User', 'following_tags', '#{tag['created_at']}')")
+    end
+    execute("DELETE FROM following_tags")
+  end
+  def down
+    sql = "SELECT tag_id, taggable_id, created_at FROM taggings WHERE  taggable_type = 'User' AND context = 'following_tags'"
+    for tagging in execute(sql)
+      execute("INSERT INTO following_tags (user_id, tag_id, created_at) VALUES(#{tagging['taggable_id']}, #{tagging['tag_id']}, '#{tagging['created_at']}')")
+    end
+    execute("DELETE FROM taggings WHERE taggable_type = 'User' AND context = 'following_tags'")
+  end
+end

--- a/db/migrate/20140723040835_drop_table_following_tag.rb
+++ b/db/migrate/20140723040835_drop_table_following_tag.rb
@@ -1,0 +1,16 @@
+class DropTableFollowingTag < ActiveRecord::Migration
+  def up
+    drop_table :following_tags
+  end
+  def down
+    create_table :following_tags do |t|
+      t.references :user, null: false, index: true
+      t.references :tag, null: false, index: true
+      t.foreign_key :users, dependent: :delete
+
+      t.timestamps
+    end
+
+    add_index :following_tags, [:user_id, :tag_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140717003617) do
+ActiveRecord::Schema.define(version: 20140723040835) do
 
   create_table "articles", force: true do |t|
     t.integer  "user_id",                                null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.integer  "lock_version",               default: 0
   end
 
-  add_index "articles", ["user_id"], name: "index_articles_on_user_id", using: :btree
+  add_index "articles", ["user_id"], name: "index_articles_on_user_id"
 
   create_table "comments", force: true do |t|
     t.integer  "user_id",    null: false
@@ -33,19 +33,8 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.datetime "updated_at"
   end
 
-  add_index "comments", ["article_id"], name: "index_comments_on_article_id", using: :btree
-  add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
-
-  create_table "following_tags", force: true do |t|
-    t.integer  "user_id",    null: false
-    t.integer  "tag_id",     null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "following_tags", ["tag_id"], name: "index_following_tags_on_tag_id", using: :btree
-  add_index "following_tags", ["user_id", "tag_id"], name: "index_following_tags_on_user_id_and_tag_id", unique: true, using: :btree
-  add_index "following_tags", ["user_id"], name: "index_following_tags_on_user_id", using: :btree
+  add_index "comments", ["article_id"], name: "index_comments_on_article_id"
+  add_index "comments", ["user_id"], name: "index_comments_on_user_id"
 
   create_table "notification_targets", force: true do |t|
     t.integer  "user_id",         null: false
@@ -54,8 +43,8 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.datetime "updated_at"
   end
 
-  add_index "notification_targets", ["notification_id"], name: "index_notification_targets_on_notification_id", using: :btree
-  add_index "notification_targets", ["user_id"], name: "index_notification_targets_on_user_id", using: :btree
+  add_index "notification_targets", ["notification_id"], name: "index_notification_targets_on_notification_id"
+  add_index "notification_targets", ["user_id"], name: "index_notification_targets_on_user_id"
 
   create_table "notifications", force: true do |t|
     t.integer  "user_id",    null: false
@@ -66,8 +55,8 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.datetime "updated_at"
   end
 
-  add_index "notifications", ["article_id"], name: "notifications_article_id_fk", using: :btree
-  add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
+  add_index "notifications", ["article_id"], name: "notifications_article_id_fk"
+  add_index "notifications", ["user_id"], name: "index_notifications_on_user_id"
 
   create_table "stocks", force: true do |t|
     t.integer  "user_id",    null: false
@@ -76,9 +65,9 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.datetime "updated_at"
   end
 
-  add_index "stocks", ["article_id"], name: "index_stocks_on_article_id", using: :btree
-  add_index "stocks", ["user_id", "article_id"], name: "index_stocks_on_user_id_and_article_id", unique: true, using: :btree
-  add_index "stocks", ["user_id"], name: "index_stocks_on_user_id", using: :btree
+  add_index "stocks", ["article_id"], name: "index_stocks_on_article_id"
+  add_index "stocks", ["user_id", "article_id"], name: "index_stocks_on_user_id_and_article_id", unique: true
+  add_index "stocks", ["user_id"], name: "index_stocks_on_user_id"
 
   create_table "taggings", force: true do |t|
     t.integer  "tag_id"
@@ -90,14 +79,14 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.datetime "created_at"
   end
 
-  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
 
   create_table "tags", force: true do |t|
     t.string  "name"
     t.integer "taggings_count", default: 0
   end
 
-  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true
 
   create_table "update_histories", force: true do |t|
     t.integer  "article_id", null: false
@@ -111,7 +100,7 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.datetime "updated_at"
   end
 
-  add_index "update_histories", ["article_id"], name: "index_update_histories_on_article_id", using: :btree
+  add_index "update_histories", ["article_id"], name: "index_update_histories_on_article_id"
 
   create_table "users", force: true do |t|
     t.string   "name",                               null: false
@@ -141,23 +130,8 @@ ActiveRecord::Schema.define(version: 20140717003617) do
     t.string   "token"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-  add_index "users", ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
-
-  add_foreign_key "articles", "users", name: "articles_user_id_fk", dependent: :delete
-
-  add_foreign_key "following_tags", "users", name: "following_tags_user_id_fk", dependent: :delete
-
-  add_foreign_key "notification_targets", "notifications", name: "notification_targets_notification_id_fk", dependent: :delete
-  add_foreign_key "notification_targets", "users", name: "notification_targets_user_id_fk", dependent: :delete
-
-  add_foreign_key "notifications", "articles", name: "notifications_article_id_fk", dependent: :delete
-  add_foreign_key "notifications", "users", name: "notifications_user_id_fk", dependent: :delete
-
-  add_foreign_key "stocks", "articles", name: "stocks_article_id_fk", dependent: :delete
-  add_foreign_key "stocks", "users", name: "stocks_user_id_fk", dependent: :delete
-
-  add_foreign_key "update_histories", "articles", name: "update_histories_article_id_fk", dependent: :delete
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
 
 end

--- a/spec/factories/following_tags.rb
+++ b/spec/factories/following_tags.rb
@@ -1,6 +1,0 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
-FactoryGirl.define do
-  factory :following_tag do
-  end
-end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,6 +1,0 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
-FactoryGirl.define do
-  factory :tag do
-  end
-end

--- a/spec/models/following_tag_spec.rb
+++ b/spec/models/following_tag_spec.rb
@@ -1,6 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe FollowingTag, :type => :model do
-  it { should belong_to(:user) }
-  it { should belong_to(:tag) }
-end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Tag, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
`acts-as-taggable-on`のタグモデルを扱うために設置していた`Tag`モデルを削除しました
`FollowingTag`は`acts-as-taggable-on`の機能で十分まかなえるため、そちらを利用するようにしました

use acts-as-taggable-on on user.following_tags

create data migration

refactor

clean up following_tags and tags model

rename tag_name to tag
