### PR TITLE
Markdown記法のヘルプを表示できる機能を追加

### DIFF
--- a/app/assets/stylesheets/articles.css.scss
+++ b/app/assets/stylesheets/articles.css.scss
@@ -10,3 +10,37 @@
     width: 60%;
   }
 }
+
+.form-editor {
+  position: relative;
+
+  .toggle-markdown-help {
+    cursor: pointer;
+    position: absolute;
+    top: 28px;
+    right: 0;
+
+    &:before {
+      padding-right: 5px;
+      vertical-align: middle;
+    }
+  }
+
+  .modal-markdown-help {
+    .modal-body {
+      overflow: auto;
+      max-height: 400px;
+
+      table {
+        th {
+          padding: 10px;
+          text-align: center;
+        }
+
+        td {
+          padding: 10px;
+        }
+      }
+    }
+  }
+}

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -20,7 +20,7 @@
     <%= f.label :tag_list %><%= tc :tags_hint %><br>
     <%= f.text_field :tag_list, :placeholder => tc("tags_example"), class: ["form-control"] %>
   </div>
-  <div class="form-group">
+  <div class="form-group form-editor">
     <%= render partial: "layouts/editor", locals: {form: f} %>
   </div>
   <div class="preview-area markdown"></div>

--- a/app/views/articles/_markdown_help.html.erb
+++ b/app/views/articles/_markdown_help.html.erb
@@ -1,0 +1,80 @@
+<a class="toggle-markdown-help glyphicon glyphicon-question-sign" data-toggle="modal" data-target=".modal-markdown-help">Markdown</a>
+
+<div class="modal fade modal-markdown-help">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title">Markdown ヘルプ</h4>
+      </div>
+      <div class="modal-body">
+        <table class="table-bordered">
+          <thead>
+            <tr>
+              <th>表示</th>
+              <th>Markdown</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>太字</td>
+              <td>**text**</td>
+            </tr>
+            <tr>
+              <td>強調表示</td>
+              <td>*text*</td>
+            </tr>
+            <tr>
+              <td>コードのインライン表示</td>
+              <td>`text`</td>
+            </tr>
+            <tr>
+              <td>シンタックスハイライト</td>
+              <td>
+                ```lang:filename<br>
+                text<br>
+                ```
+              </td>
+            </tr>
+            <tr>
+              <td>リンク</td>
+              <td>[text](http://www.example.com/)</td>
+            </tr>
+            <tr>
+              <td>見出し</td>
+              <td>
+                # text<br>
+                ## text<br>
+                ### text
+              </td>
+            </tr>
+            <tr>
+              <td>箇条書き</td>
+              <td>
+                - text<br>
+                - text<br>
+                - text
+              </td>
+            </tr>
+            <tr>
+              <td>番号付きの箇条書き</td>
+              <td>
+                1. text<br>
+                2. text<br>
+                3. text
+              </td>
+            </tr>
+            <tr>
+              <td>水平線</td>
+              <td>---</td>
+            </tr>
+            <tr>
+              <td>引用</td>
+              <td>&gt; text</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_editor.html.erb
+++ b/app/views/layouts/_editor.html.erb
@@ -11,3 +11,4 @@
     <div class="preview-area markdown panel-body"></div>
   </div>
 </div>
+<%= render 'articles/markdown_help' %>


### PR DESCRIPTION
#6

動作的にはQiitaとほぼ同じです。
Bootstrapが元々使われているようなので、modalを使って表示させています。

![1](https://cloud.githubusercontent.com/assets/4456532/3809909/74a70256-1c89-11e4-81a1-c1ebfb500752.png)

![2](https://cloud.githubusercontent.com/assets/4456532/3809910/74ab1026-1c89-11e4-81ea-14d57aeabf2c.png)

開発ガイドにも目を通してみたのですが、手違いなどあったらご指摘くださいm(_ _)m
