### PR TITLE
Markdown周りのスタイルやコードブロック内の処理を変更。

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -123,13 +123,29 @@ body {
 
   blockquote {
     font-size: 1em;
+    padding: 0 10px;
+    margin-left: 20px;
+
+    > p:first-child {
+      margin-top: 0;
+    }
+  }
+
+  code {
+    font-size: 100%;
+  }
+
+  .code-filename {
   }
 
   // fix CodeRay design
   .CodeRay {
+    margin-bottom: 10px;
+
     pre {
+      font-size: 100%;
       border: none;
-      @include border-radius(0);
+      margin: 0;
     }
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,8 +7,8 @@ module ApplicationHelper
       title = $1 || ""
       begin
         code = CGI.unescapeHTML code
-        code = CodeRay.scan(code, language).div(:line_numbers => :table)
-        code.sub("<tr>", create_filename_row(title) + "<tr>")
+        code = CodeRay.scan(code, language).div()
+        code.sub(/^/, create_filename_row(title))
       rescue
         self.block_code(title + code, :text)
       end
@@ -20,7 +20,7 @@ module ApplicationHelper
 
     def create_filename_row(filename)
       return "" if filename.empty?
-      %!<tr class="code-filename-row"><th colspan="2">#{filename.gsub("@@@", "")}</th></tr>!
+      %!<div class="code-filename">#{filename.gsub("@@@", "")}</div>!
     end
   end
 

--- a/lib/assets/stylesheets/bootswatch/lodge/_bootswatch.scss
+++ b/lib/assets/stylesheets/bootswatch/lodge/_bootswatch.scss
@@ -98,6 +98,28 @@ nav.well {
     padding: 3px 10px;
     text-shadow: 1px 1px #eee;
   }
+
+  code {
+    border: 1px solid $pre-border-color;
+    border-radius: 3px;
+  }
+
+  .code-filename {
+    background-color: darken($pre-bg, 3);
+    border: 1px solid #ccc;
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+    padding: 3px 5px;
+  }
+
+  .CodeRay {
+    border: 1px solid $pre-border-color;
+    border-radius: 4px;
+  }
+
+  .code-filename + .CodeRay {
+    border-radius: 0 0 4px 4px;
+  }
 }
 
 .label.label-default{


### PR DESCRIPTION
- コードブロックに行番号を表示しないよう仕様変更。
- 上記に伴いコードブロックのファイル名表示のロジックを変更。
- コードブロックで横幅を超える文字列があった場合に自動で折り返すよう修正。
- Markdown内のスタイルを一部修正。
