### PR TITLE
記事の最終更新者が、全記事内で共通になってしまう不具合の修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -69,7 +69,7 @@ class Article < ActiveRecord::Base
   # ===== Instance methods =====
 
   def last_updated_user
-    UpdateHistory.includes(:user).order(created_at: :desc).first.user
+    update_histories.order(created_at: :desc).first.user
   end
 
   def save

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -24,14 +24,14 @@
   <div class="article-detail-area panel-body">
     <div class="text-right">
       <%= tco :created_at  %>:
-      <span class="dropdown">
+      <span class="dropdown created-by">
         <%= render partial: "users/info_dropdown", locals: {user: @article.user} %> -
       </span>
       <%= @article.created_at %>
       <% if @article.update_histories.size > 0 %>
         |
         <%= tco :updated_at  %>:
-        <span class="dropdown">
+        <span class="dropdown updated-by">
           <%= render partial: "users/info_dropdown", locals: { user: @article.last_updated_user } %> -
         </span>
         <%= @article.updated_at %>

--- a/spec/features/edit_articles_spec.rb
+++ b/spec/features/edit_articles_spec.rb
@@ -101,4 +101,36 @@ feature 'Edit articles', type: :feature do
       end
     end
   end
+
+  context 'when multiple articles' do
+    let(:article1_attrs) do
+      { title: 'old article1', tag_list: '1', body: 'old body' }
+    end
+    let(:article2_attrs) do
+      { title: 'old article2', tag_list: '2', body: 'old body' }
+    end
+    let(:article1) { FactoryGirl.create(:article, article1_attrs) }
+    let(:article2) { FactoryGirl.create(:article, article2_attrs) }
+
+    let(:user1) { FactoryGirl.create(:user) }
+    let(:user2) { FactoryGirl.create(:user) }
+
+    background do
+      article1.update(update_user_id: user1.id)
+      article2.update(update_user_id: user2.id)
+      login_as user1, scope: :user
+    end
+
+    scenario 'Update articles for each other users' do
+      visit article_path(article1)
+      within '.article-detail-area' do
+        expect(find('.updated-by')).to have_content user1.name
+      end
+
+      visit article_path(article2)
+      within '.article-detail-area' do
+        expect(find('.updated-by')).to have_content user2.name
+      end
+    end
+  end
 end


### PR DESCRIPTION
#145 の修正対応です。
