### PR TITLE
Change the order of installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ http://lodge-sample.herokuapp.com/
     ```
 
 1. `bundle install --path vendor/bundle` を実行し、依存ライブラリをインストールします。
-1. `bundle exec rake db:create RAILS_ENV=production` を実行し、データベースを作成します。
-1. `bundle exec rake db:migrate RAILS_ENV=production` を実行し、テーブルを作成します。
 1. `.env.example` を `.env` としてコピーし、必要な環境変数を設定します。各コメントを参考に設定してください。最低限設定が必要な項目は以下の通りです。
 
     ```ruby
@@ -139,6 +137,8 @@ http://lodge-sample.herokuapp.com/
     # テーマを設定します。
     LODGE_THEME       = lodge
     ```
+1. `bundle exec rake db:create RAILS_ENV=production` を実行し、データベースを作成します。
+1. `bundle exec rake db:migrate RAILS_ENV=production` を実行し、テーブルを作成します。
 
 ## 絵文字の準備
 


### PR DESCRIPTION
ちょっと細かいのですが、READMEに記載されたインストール方法の順序だとdb:migrate に失敗しました。
`ENV["DELIVERY_METHOD"].to_sym` で `NoMethodError` になります。

```
yasuhiroki@ ~/gh/lodge $ bundle exec rake db:migrate RAILS_ENV=production
NoMethodError: undefined method `to_sym' for nil:NilClass
/home/yasuhiroki/gh/lodge/config/environments/production.rb:94:in `block in <top (required)>'
(略)
```

とりあえず手順を入れ替えて、`.env` を先に設定するようにすれば解決しました。
