### PR TITLE
アセットがない場合の為にヘルパーを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,4 +76,18 @@ module ApplicationHelper
   def next_uuid
     SecureRandom.uuid
   end
+
+  def controller_stylesheet_link_tag
+    stylesheet = "#{params[:controller]}.css"
+    unless Rails.application.assets.find_asset(stylesheet).nil?
+      stylesheet_link_tag stylesheet, media: "all"
+    end
+  end
+
+  def controller_javascript_include_tag
+    javascript = "#{params[:controller]}.js" #e.g. home_controller =>assets/javascripts/home.js
+    unless Rails.application.assets.find_asset(javascript).nil?
+      javascript_include_tag javascript
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,8 @@
     <%= javascript_include_tag 'externals/respond.min', 'data-turbolinks-track' => true %>
     <![endif]-->
     <%= stylesheet_link_tag "pygments-css/#{ENV['SYNTAX_HIGHLIGHT_THEME']}", media: 'all', 'data-turbolinks-track' => true %>
-    <%= stylesheet_link_tag controller.controller_name, media: "all" %>
-    <%= javascript_include_tag controller.controller_name %>
+    <%= controller_stylesheet_link_tag %>
+    <%= controller_javascript_include_tag %>
   </head>
   <body>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe ApplicationHelper do
+  describe '#controller_stylesheet_link_tag' do
+    subject(:tag) { helper.controller_stylesheet_link_tag }
+
+    before do
+      allow(helper).to receive(:params) { {controller: controller_name} }
+    end
+
+    context "assetsにファイルがないとき" do
+      let(:controller_name) { 'hoge/fuga' }
+
+      it "linkタグが生成されないこと" do
+        expect(tag).to be_nil
+      end
+    end
+
+    context "assetsにファイルがあるとき" do
+      let(:controller_name) { 'custom_devise/registrations' }
+
+      it "linkタグが生成されること" do
+        expect(tag).to match /link/
+        expect(tag).to match /assets\/#{controller_name.gsub('/','\/')}\.css/
+      end
+    end
+  end
+
+  describe '#controller_javascript_include_tag' do
+    subject(:tag) { helper.controller_javascript_include_tag }
+
+    before do
+      allow(helper).to receive(:params) { {controller: controller_name} }
+    end
+
+    context "assetsにファイルがないとき" do
+      let(:controller_name) { 'hoge/fuga' }
+
+      it "scriptタグが生成されないこと" do
+        expect(tag).to be_nil
+      end
+    end
+
+    context "assetsにファイルがあるとき" do
+      let(:controller_name) { 'articles' }
+
+      it "scriptタグが生成されること" do
+        expect(tag).to match /script/
+        expect(tag).to match /assets\/#{controller_name.gsub('/','\/')}\.js/
+      end
+    end
+  end
+end


### PR DESCRIPTION
レイアウトのcontroller毎にcss, jsを読み込んでいる箇所で、
**ファイルが存在しない場合** はタグを生成しないようにしました。

手元の別の変更に影響があったので… ( `quiet_assets`でエラーでました :scream_cat: )
## 劇的
### ビフォー

![before](https://cloud.githubusercontent.com/assets/147351/8084924/822df4f6-0fc8-11e5-83dc-f39b05f52174.png)
### アフター

![after](https://cloud.githubusercontent.com/assets/147351/8084947/a88bc164-0fc8-11e5-98cd-b33f29438f01.png)
