### PR TITLE
 Certificate Verify Failed対策

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,8 @@ SMTP_PASSWORD             = password
 SMTP_AUTH_METHOD          = plain
 SMTP_ENABLE_STARTTLS_AUTO = true
 
-# サーバーの証明書検証に関する設定です（Certificate Verify Failed対策)
+# サーバーの証明書検証に関する設定（Certificate Verify Failed等の対策が必要な場合）
+# 設定値: none, peer, client_once, fail_if_no_peer_cert
 # SMTP_OPENSSL_VERIFY_MODE  = none
 
 # テーマを設定します。

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ SMTP_PASSWORD             = password
 SMTP_AUTH_METHOD          = plain
 SMTP_ENABLE_STARTTLS_AUTO = true
 
+# サーバーの証明書検証に関する設定です（Certificate Verify Failed対策)
+# SMTP_OPENSSL_VERIFY_MODE  = none
+
 # テーマを設定します。
 LODGE_THEME             = lodge
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,5 +69,6 @@ Rails.application.configure do
     :password             => ENV["SMTP_PASSWORD"],
     :authentication       => ENV["SMTP_AUTH_METHOD"].to_sym,
     :enable_starttls_auto => ENV["SMTP_ENABLE_STARTTLS_AUTO"],
+    :openssl_verify_mode  => ENV["SMTP_OPENSSL_VERIFY_MODE"] || OpenSSL::SSL::VERIFY_PEER
   }
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,6 +69,7 @@ Rails.application.configure do
     :password             => ENV["SMTP_PASSWORD"],
     :authentication       => ENV["SMTP_AUTH_METHOD"].to_sym,
     :enable_starttls_auto => ENV["SMTP_ENABLE_STARTTLS_AUTO"],
-    :openssl_verify_mode  => ENV["SMTP_OPENSSL_VERIFY_MODE"] || OpenSSL::SSL::VERIFY_PEER
   }
+
+  config.action_mailer.smtp_settings[:openssl_verify_mode] = ENV["SMTP_OPENSSL_VERIFY_MODE"] if ENV["SMTP_OPENSSL_VERIFY_MODE"].present?
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,5 +100,6 @@ Rails.application.configure do
     :password             => ENV["SMTP_PASSWORD"],
     :authentication       => ENV["SMTP_AUTH_METHOD"].to_sym,
     :enable_starttls_auto => ENV["SMTP_ENABLE_STARTTLS_AUTO"],
+    :openssl_verify_mode  => ENV["SMTP_OPENSSL_VERIFY_MODE"] || OpenSSL::SSL::VERIFY_PEER
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,7 @@ Rails.application.configure do
     :password             => ENV["SMTP_PASSWORD"],
     :authentication       => ENV["SMTP_AUTH_METHOD"].to_sym,
     :enable_starttls_auto => ENV["SMTP_ENABLE_STARTTLS_AUTO"],
-    :openssl_verify_mode  => ENV["SMTP_OPENSSL_VERIFY_MODE"] || OpenSSL::SSL::VERIFY_PEER
   }
+
+  config.action_mailer.smtp_settings[:openssl_verify_mode] = ENV["SMTP_OPENSSL_VERIFY_MODE"] if ENV["SMTP_OPENSSL_VERIFY_MODE"].present?
 end


### PR DESCRIPTION
アカウント登録時、メールを送信する際、OPENSSL_VERIFY_MODEの設定が必要なSMTPサーバーの場合、メールの送信に失敗してしまうため（Certificate Verify Failed）、オプションを付与できるよう対策をしました。
お手すきの際、見ていただければ幸いですm(__)m

参考URL
Rails 3 ActionMailer error - hostname was not match with the server certificate - Stack Overflow http://stackoverflow.com/questions/5021416/rails-3-actionmailer-error-hostname-was-not-match-with-the-server-certificate
