### PR TITLE
Enable to transition article comment from list.

### DIFF
--- a/app/views/articles/_comment_count.html.erb
+++ b/app/views/articles/_comment_count.html.erb
@@ -1,3 +1,3 @@
 <%= content_tag :span, title: tco(:comment) do %>
-  <a href="#comment-list-title"><%= image_tag "comment.png" %><%= article.comments.size %></a>
+  <%= link_to "#{image_tag('comment.png')}#{article.comments.size}".html_safe, "#{article_path(article.id)}#comment-list-title" %>
 <% end %>


### PR DESCRIPTION
記事一覧のページから記事のコメント数のアイコン・数値をクリックした時、
対象の記事のコメント部分へ遷移する方が自然だと思いましたので修正しました。

↓修正後のリンク先URLの例
![fixed-link](https://cloud.githubusercontent.com/assets/3108110/9039719/57a995c4-3a38-11e5-9b6c-3063218f5112.png)

問題なければマージをお願いします:smile:
