### PR TITLE
Add settings into the .env for configuring url to the header title link.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,12 @@ SMTP_ENABLE_STARTTLS_AUTO = true
 # テーマを設定します。
 LODGE_THEME             = lodge
 
+# ページヘッダ部のタイトル(Lodge)をクリックした際のリンク先ページを設定します。
+# 以下のいずれかを選択してください。
+# feeds => フィード一覧(デフォルト)
+# articles => 最新記事一覧
+TITLE_LINK_URL = feeds
+
 # シンタックスハイライトのテーマを設定します。
 # 選択できるテーマは以下の通りです。
 # autumn, monokai, borland, murphy, bw, native, colorful, pastie,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,8 @@
         <div class="container-fluid">
           <div class="row">
             <div class="col-xs-4">
-              <h1 class="navbar-header"><%= link_to "Lodge", root_path, class: ["nav", "navbar-brand"] %></h1>
+              <% title_link_url = (ENV['TITLE_LINK_URL'] == 'articles') ? articles_path : root_path %>
+              <h1 class="navbar-header"><%= link_to "Lodge", title_link_url, class: ["nav", "navbar-brand"] %></h1>
             </div>
             <div class="col-xs-8">
               <div class="row">


### PR DESCRIPTION
ヘッダ部のタイトル(Lodge)をクリックした際に飛ぶリンク先を.envで設定できるようにしました。
これにより、ユーザ数の少ない場合に於けるフィードの不便さを若干緩和します。
(root_pathそのものを変更するのは、これでもどうしても使いにくい場合に再度検討したいと思います)
