### PR TITLE
Fix shoulda-matchers "undefined method ..."

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,12 +14,24 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
 require 'coveralls'
 Coveralls.wear!('rails')
+
+
+# Fix "undefined method" to matchers of shoulda-matchers
+# These code came from https://github.com/thoughtbot/shoulda/issues/203#issuecomment-187430142
+require 'active_support/test_case'
+require 'action_controller'
+require "shoulda/matchers"
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
 
 RSpec.configure do |config|
 # The settings below are suggested to provide a good initial experience


### PR DESCRIPTION
rspecを実行すると以下のようなエラーが複数出たので解決しました。

``` ruby
38) Stock 
      Failure/Error: it { should validate_uniqueness_of(:user).scoped_to(:article_id) }

      NoMethodError:
        undefined method `validate_uniqueness_of' for #<RSpec::ExampleGroups::Stock:0x0000000b628940>
      # ./spec/models/stock_spec.rb:8:in `block (2 levels) in <top (required)>'
```

但し、別のエラーが出てしまいこちらは解決できませんでした。
undefined method error自体は解決できたのでpull requestにしました。

``` ruby
  1) CreateArticles create new article
     Failure/Error: click_link I18n.t("common.user_article_list_title")

     Capybara::Poltergeist::MouseEventFailed:
       Firing a click at co-ordinates [821.5, 66.5] failed. Poltergeist detected another element with CSS selector 'html body div.container div.navbar.navbar-default div.container-fluid div.row div.col-xs-8 div.global-menu-list.row.navbar-right ul.navbar-text.list-inline li.dropdown' at this position. It may be overlapping the element you are trying to interact with. If you don't care about overlapping elements, try using node.trigger('click').
     # ./spec/features/create_articles_spec.rb:28:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Capybara::Poltergeist::BrowserError:
     #   There was an error inside the PhantomJS portion of Poltergeist. If this is the error returned, and not the cause of a more detailed error response, this is probably a bug, so please report it. 
     #   
     #   Poltergeist.MouseEventFailed: click
     #   html body div.container div.navbar.navbar-default div.container-fluid div.row div.col-xs-8 div.global-menu-list.row.navbar-right ul.navbar-text.list-inline li.dropdown
     #   {"x"=>821.5, "y"=>66.5}
     #   ./spec/features/create_articles_spec.rb:28:in `block (2 levels) in <top (required)>'

  2) Stock should validate that :user is case-sensitively unique within the scope of :article_id
     Failure/Error: it { should validate_uniqueness_of(:user).scoped_to(:article_id) }

       Stock did not properly validate that :user is case-sensitively unique
       within the scope of :article_id.
         Expected the validation to be scoped to :article_id, but it was scoped
         to :article instead.
     # ./spec/models/stock_spec.rb:8:in `block (2 levels) in <top (required)>'
```
