### PR TITLE
remove duplicate gem 'rspec-parameterized'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ group :test do
   gem 'poltergeist'
   gem 'database_cleaner'
   gem 'launchy'
-  gem 'rspec-parameterized'
   gem 'codeclimate-test-reporter', group: :test, require: nil
 end
 


### PR DESCRIPTION
>Your Gemfile lists the gem rspec-parameterized (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.