### PR TITLE
Gemfileのバージョン指定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,8 @@ gem 'compass-rails', '~> 2.0'
 gem 'omniauth-google-oauth2', '~> 0.2'
 gem 'carrierwave', '~> 0.10'
 gem 'jquery-fileupload-rails', '~> 0.4'
-gem 'qiita-markdown'
+gem 'qiita-markdown', '~> 0.14.0'
+gem 'gemoji', '~> 2.0'
 
 group :development do
   gem 'bullet'

--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ group :test do
   gem 'database_cleaner'
   gem 'launchy'
   gem 'rspec-parameterized'
-  gem 'codeclimate-test-reporter', group: :test, require: nil
+  gem 'codeclimate-test-reporter', '~> 0.6.0', group: :test, require: nil
 end
 
 # Include database gems for the adapters found in the database


### PR DESCRIPTION
* 記事表示でqiita-markdownのエラーが出るため(0.15から引数が変わった)
* rakeコマンドでエラーが出るため(gemoji3からtask/emoji.rakeがない)
* ruby-test-reporter1.0以降でエラーが出るため